### PR TITLE
Fix checks for every_subject_or_below

### DIFF
--- a/events/dvg_dua.txt
+++ b/events/dvg_dua.txt
@@ -2787,8 +2787,13 @@ dvg_dua.500 = { #Total Revolution
 		}
 
 		every_subject_or_below = {
-			limit = { 
-				is_subject_of = ROOT
+			limit = {
+				OR = {
+					is_subject_type = subject_type_vassal
+					is_subject_type = subject_type_protectorate
+					is_subject_type = subject_type_dominion
+					is_subject_type = subject_type_puppet
+				}
 			}
 
 			make_independent = yes

--- a/events/dvg_dua.txt
+++ b/events/dvg_dua.txt
@@ -2788,6 +2788,7 @@ dvg_dua.500 = { #Total Revolution
 
 		every_subject_or_below = {
 			limit = {
+				is_subject_of = ROOT
 				OR = {
 					is_subject_type = subject_type_vassal
 					is_subject_type = subject_type_protectorate

--- a/events/dvg_lotharingia.txt
+++ b/events/dvg_lotharingia.txt
@@ -499,6 +499,15 @@ s:STATE_MARCHES_OUEST = {
 		
 
 		every_subject_or_below = {
+			limit = {
+				OR = {
+					is_subject_type = subject_type_vassal
+					is_subject_type = subject_type_protectorate
+					is_subject_type = subject_type_dominion
+					is_subject_type = subject_type_puppet
+				}
+			}
+			
 			make_independent = yes
 		}
 

--- a/events/dvg_lotharingia.txt
+++ b/events/dvg_lotharingia.txt
@@ -500,6 +500,7 @@ s:STATE_MARCHES_OUEST = {
 
 		every_subject_or_below = {
 			limit = {
+				is_subject_of = ROOT
 				OR = {
 					is_subject_type = subject_type_vassal
 					is_subject_type = subject_type_protectorate

--- a/events/russia/dvg_nov_events.txt
+++ b/events/russia/dvg_nov_events.txt
@@ -204,11 +204,10 @@ dvg_nov.3 = {
 
 		every_subject_or_below = {
 			limit = {
-				OR = {
-					is_subject_type = subject_type_vassal
-					is_subject_type = subject_type_protectorate
-					is_subject_type = subject_type_dominion
-					is_subject_type = subject_type_puppet
+				is_subject_of = ROOT
+				NOT = {
+					is_subject_type = subject_type_customs_union
+					is_subject_type = subject_type_personal_union
 				}
 			}
 
@@ -332,11 +331,10 @@ dvg_nov.4 = {
 
 		every_subject_or_below = {
 			limit = {
-				OR = {
-					is_subject_type = subject_type_vassal
-					is_subject_type = subject_type_protectorate
-					is_subject_type = subject_type_dominion
-					is_subject_type = subject_type_puppet
+				is_subject_of = ROOT
+				NOT = {
+					is_subject_type = subject_type_customs_union
+					is_subject_type = subject_type_personal_union
 				}
 			}
 

--- a/events/russia/dvg_nov_events.txt
+++ b/events/russia/dvg_nov_events.txt
@@ -203,8 +203,13 @@ dvg_nov.3 = {
 		}
 
 		every_subject_or_below = {
-			limit = { 
-				is_subject_of = ROOT
+			limit = {
+				OR = {
+					is_subject_type = subject_type_vassal
+					is_subject_type = subject_type_protectorate
+					is_subject_type = subject_type_dominion
+					is_subject_type = subject_type_puppet
+				}
 			}
 
 			make_independent = yes
@@ -326,8 +331,13 @@ dvg_nov.4 = {
 		}
 
 		every_subject_or_below = {
-			limit = { 
-				is_subject_of = ROOT
+			limit = {
+				OR = {
+					is_subject_type = subject_type_vassal
+					is_subject_type = subject_type_protectorate
+					is_subject_type = subject_type_dominion
+					is_subject_type = subject_type_puppet
+				}
 			}
 
 			make_independent = yes


### PR DESCRIPTION
Should check for subject types, so we do not release market subjects, and their subjects.