### PR TITLE
Update 00_west_europe.txt

### DIFF
--- a/common/history/buildings/00_west_europe.txt
+++ b/common/history/buildings/00_west_europe.txt
@@ -3960,6 +3960,12 @@
 				reserves=1
 				activate_production_methods={ "pm_atmospheric_engine_pump_building_coal_mine" "pm_no_explosives" "pm_no_steam_automation" "pm_road_carts" "pm_privately_owned_building_coal_mine" }
 			}
+			create_building={
+				building="building_railway"
+				level=2
+				reserves=1
+				activate_production_methods={ "pm_steam_trains" "pm_no_passenger_trains" }
+			}	
 		}
 	}
 	s:STATE_MORAVIA={
@@ -4012,13 +4018,25 @@
 				reserves=1
 				activate_production_methods={ "pm_atmospheric_engine_pump_building_coal_mine" "pm_no_explosives" "pm_no_steam_automation" "pm_road_carts" "pm_privately_owned_building_coal_mine" }
 			}
+			create_building={
+				building="building_paper_mills"
+				level=4
+				reserves=1
+				activate_production_methods={ "pm_sulfite_pulping" "pm_automation_disabled" "pm_privately_owned_building_paper_mills" }
+			}
+			create_building={
+				building="building_motor_industry"
+				level=1
+				reserves=1
+				activate_production_methods={ "pm_steam_engines" "pm_automobiles_disabled" "pm_automation_disabled" "pm_privately_owned_industry" }
+			}
 		}
 	}
 	s:STATE_SILESIA={
 		region_state:BOH={
 			create_building={
 				building="building_government_administration"
-				level=2
+				level=3
 				reserves=1
 				activate_production_methods={ "pm_vertical_filing_cabinets" }
 			}
@@ -4094,7 +4112,7 @@
 			}
 			create_building={
 				building="building_glassworks"
-				level=5
+				level=8
 				reserves=1
 				activate_production_methods={ "pm_leaded_glass" "pm_privately_owned_building_glassworks" "pm_manual_glassblowing" "pm_ceramics" }
 			}
@@ -4133,23 +4151,11 @@
 	s:STATE_BRANDENBURG={
 		region_state:BOH={
 			create_building={
-				building="building_government_administration"
-				level=1
-				reserves=1
-				activate_production_methods={ "pm_vertical_filing_cabinets" }
-			}
-			create_building={
 				building="building_construction_sector"
 				level=3
 				reserves=1
 				activate_production_methods={ "pm_iron_frame_buildings" }
 			}				
-			create_building={
-				building="building_university"
-				level=1
-				reserves=1
-				activate_production_methods={ "pm_scholastic_education" }
-			}
 			create_building={
 				building="building_arms_industry"
 				level=5
@@ -4161,18 +4167,6 @@
 				level=5
 				reserves=1
 				activate_production_methods={ "pm_lathe" "pm_privately_owned_building_furniture_manufacturies" "pm_automation_disabled" "pm_luxury_furniture" }
-			}
-			create_building={
-				building="building_glassworks"
-				level=3
-				reserves=1
-				activate_production_methods={ "pm_leaded_glass" "pm_privately_owned_building_glassworks" "pm_manual_glassblowing" "pm_ceramics" }
-			}
-			create_building={
-				building="building_paper_mills"
-				level=4
-				reserves=1
-				activate_production_methods={ "pm_sulfite_pulping" "pm_automation_disabled" "pm_privately_owned_building_paper_mills" }
 			}
 			create_building={
 				building="building_barracks"
@@ -4213,6 +4207,12 @@
 				level=20
 				reserves=1
 				activate_production_methods={ "pm_skirmish_infantry" "pm_mobile_artillery" "pm_cavalry_scouts" "pm_no_specialists" "pm_wound_dressing" }
+			}
+			create_building={
+				building="building_university"
+				level=1
+				reserves=1
+				activate_production_methods={ "pm_scholastic_education" }
 			}
 		}
 	}

--- a/common/history/buildings/00_west_europe.txt
+++ b/common/history/buildings/00_west_europe.txt
@@ -3896,7 +3896,7 @@
 			}			
 			create_building={
 				building="building_construction_sector"
-				level=2
+				level=3
 				reserves=1
 				activate_production_methods={ "pm_iron_frame_buildings" }
 			}				
@@ -4146,16 +4146,16 @@
 				reserves=1
 				activate_production_methods={ "pm_skirmish_infantry" "pm_mobile_artillery" "pm_cavalry_scouts" "pm_no_specialists" "pm_wound_dressing" }
 			}
+			create_building={
+				building="building_construction_sector"
+				level=2
+				reserves=1
+				activate_production_methods={ "pm_iron_frame_buildings" }
+			}
 		}
 	}
 	s:STATE_BRANDENBURG={
-		region_state:BOH={
-			create_building={
-				building="building_construction_sector"
-				level=3
-				reserves=1
-				activate_production_methods={ "pm_iron_frame_buildings" }
-			}				
+		region_state:BOH={				
 			create_building={
 				building="building_arms_industry"
 				level=5


### PR DESCRIPTION
Changed building set-up for Bohemia. Reshuffled the starting buildings, mainly put manufactories from Branden burg into other states as follows :
University to Anhalt (I thought of the very old Wittenberg university), Glass manufactories to Saxony, Construction sectors to Bohemia proper and Saxony, Gov administration to Silesia, Paper Mills to Moravia.
This is mainly done due to Brandenburg being much less developed in this timeline, so they shouldn't start as one of the most urbanized states, aswell as to combat the starting unemployed issue and make better use of arable land.
Also added one Motor industries to Moravia and 2 Railways to Bohemia proper so that the state starts with sufficient market access