### PR TITLE
There Just Wasn't Any Significant Gold

### DIFF
--- a/common/history/buildings/01_south_europe.txt
+++ b/common/history/buildings/01_south_europe.txt
@@ -1044,12 +1044,6 @@
 				reserves=1
 				activate_production_methods={ "pm_basic_port" }
 			}
-			create_building={
-				building="building_gold_mine"
-				level=1
-				reserves=1
-				activate_production_methods={ "pm_picks_and_shovels_building_gold_mine" "pm_no_explosives" "pm_no_steam_automation" "pm_road_carts" "pm_merchant_guilds_building_gold_mine" }
-			}
 		}
 	}
 	s:STATE_SICILY={

--- a/map_data/state_regions/01_south_europe.txt
+++ b/map_data/state_regions/01_south_europe.txt
@@ -410,7 +410,6 @@ STATE_SARDINIA = {
         bg_iron_mining = 21
         bg_lead_mining = 21
         bg_sulfur_mining = 20
-        bg_gold_mining = 2
         bg_logging = 12
         bg_fishing = 10
     }


### PR DESCRIPTION
I. There is no record of a significant amount of gold being produced in Sicily, let alone Italy as a whole, in this time period.(1)

II. If this gold mine is meant to represent the production of silver and other precious metals used in minting purposes, Mexico produced 2,000 times as much silver than all of Italy combined between 1841 and 1851, the earliest period on record.(2)

III. If we are to diverge resource endowment from the base game, we would have to do systematically to the entire map consistently, which, in light of the above figures, would require significant research; an undertaking that is both prohibitive and contrary to the mod's philosophy of touching as little of vanilla as possible.

IV. If the argument is to be made that this has little impact, then the same argument can be made against adding it. This is not a matter of flavor, it is simply a buff to Aragon that, as far as I can find, is unsubstantiated by any data.

sources:
1. Klein Goldewijk, Kees and Jonathan Fink-Jensen (2015). Gold Production. http://hdl.handle.net/10622/MRQ2XJ, accessed via the Clio Infra website.
2. White Merrill, Charles (1930). Summarized Data of Silver Production. US Department of Commerce. Economic Paper 8.