### PR TITLE
Australie

### DIFF
--- a/common/country_definitions/dvg_oceania.txt
+++ b/common/country_definitions/dvg_oceania.txt
@@ -294,7 +294,7 @@ NVZ = { #Nouvelle Zealand
 	color = { 150 0 0 }
 	country_type = colonial
 	
-	tier = principality
+	tier = grand_principality
 	
 	cultures = { verlander }
 	
@@ -339,10 +339,10 @@ AST = { #Australia
 	
 	country_type = colonial
 	
-	tier = empire
+	tier = kingdom
 	
 	capital = STATE_NOONGAR
-	cultures = { verlander}
+	cultures = { verlander ny_sjaellander }
 }
 
 

--- a/common/country_formation/dvg_formables_oceania.txt
+++ b/common/country_formation/dvg_formables_oceania.txt
@@ -69,7 +69,7 @@ AST = { #Australia
 	
 	use_culture_states = yes
 
-	required_states_fraction = .67
+	required_states_fraction = 1
 	
 	ai_will_do = { always = yes }
 

--- a/common/dynamic_country_names/dvg_dynamic_country_names.txt
+++ b/common/dynamic_country_names/dvg_dynamic_country_names.txt
@@ -3505,8 +3505,8 @@ KMT = {
 #Australia
 AST = { 
 	dynamic_country_name = {
-		name = dyn_c_mamluk_caliphate
-		adjective = dyn_c_mamluk_caliphate_adj
+		name = dyn_c_scandinavian_australia
+		adjective = dyn_c_scandinavian_australia_adj
 
 		is_main_tag_only = yes
 		priority = 3

--- a/common/dynamic_country_names/dvg_dynamic_country_names.txt
+++ b/common/dynamic_country_names/dvg_dynamic_country_names.txt
@@ -3501,3 +3501,25 @@ KMT = {
 		}
 	}
 }
+
+#Australia
+AST = { 
+	dynamic_country_name = {
+		name = dyn_c_mamluk_caliphate
+		adjective = dyn_c_mamluk_caliphate_adj
+
+		is_main_tag_only = yes
+		priority = 3
+		
+		trigger = {
+			exists = scope:actor
+			scope:actor = { 
+				OR = {
+					was_formed_from = NYS
+					was_formed_from = VRG
+				}
+			}
+			
+		}
+	}
+}

--- a/localization/english/dvg_countries_l_english.yml
+++ b/localization/english/dvg_countries_l_english.yml
@@ -658,7 +658,7 @@
  AST_ADJ: "Australien"
  dyn_c_scandinavian_australia: "Australien"
  dyn_c_scandinavian_australia_adj: "Australsk"
- #Australien ended up also being the danish way to say it.
+ #Australien ended up being the danish way to say australia, australsk is the danish way to say australian. This is according to MTL.
 
  
  #Asia

--- a/localization/english/dvg_countries_l_english.yml
+++ b/localization/english/dvg_countries_l_english.yml
@@ -654,6 +654,11 @@
  GNS_ADJ: "Hongshan"
  dyn_c_tui_tonga: "Tui Tonga"
  TNG_adj: "Tongan"
+ AST: "Australie"
+ AST_ADJ: "Australien"
+ dyn_c_scandinavian_australia: "Australien"
+ dyn_c_scandinavian_australia_adj: "Australien"
+ #Australien ended up also being the danish way to say it.
 
  
  #Asia

--- a/localization/english/dvg_countries_l_english.yml
+++ b/localization/english/dvg_countries_l_english.yml
@@ -657,7 +657,7 @@
  AST: "Australie"
  AST_ADJ: "Australien"
  dyn_c_scandinavian_australia: "Australien"
- dyn_c_scandinavian_australia_adj: "Australien"
+ dyn_c_scandinavian_australia_adj: "Australsk"
  #Australien ended up also being the danish way to say it.
 
  

--- a/localization/english/dvg_cultures_l_english.yml
+++ b/localization/english/dvg_cultures_l_english.yml
@@ -2,7 +2,7 @@
  #Cultures
  anglois:0 "Anglois"
  burgundian:0 "Burgundian"
- verlander:0 "Australian"
+ verlander:0 "Australien"
  vinlander:0 "Vinlander"
  septiman:0 "Septiman"
  cadien:0 "Cadien"


### PR DESCRIPTION
Australian -> Australien
AST and AST_ADJ have been defined
BEI can no longer form Australie
AST is a tag that has both Modpolic and Australien.
Required 100% of the states to form the Country, to make it something that can be pushed for in a NVZ  or Ny sjaelland game.