### PR TITLE
Fixing Xijao Missions

### DIFF
--- a/common/modifiers/DVG_CHI_modifiers.txt
+++ b/common/modifiers/DVG_CHI_modifiers.txt
@@ -53,7 +53,7 @@ dvg_exporting_missionaries = {
 dvg_xijao_missions = {
 	icon = gfx/interface/icons/timed_modifier_icons/modifier_documents_negative.dds
     state_radicals_from_discrimination_mult = 0.5
-	state_education_access_wealth_add = 0.10
+	state_education_access_wealth_add = 0.005
 	state_turmoil_effects_mult = 0.15
 }
 dvg_village_pillage = {


### PR DESCRIPTION
The current modifier for education is way too high, essentially several times more powerful than normal Private Education, resulting in those states being some of the most literate on the planet.

Reduced the education modifier to bring it much more in line with similar modifiers and being beneficial compared to the negatives from the modifier, but not broken as it was.