### PR TITLE
Fix Batavia Events

### DIFF
--- a/events/dvg_south_africa/dvg_batavia.txt
+++ b/events/dvg_south_africa/dvg_batavia.txt
@@ -25,6 +25,9 @@ dvg_batavia.1 = {
 		c:BTV = {
 			is_subject = no 
 		}
+		NOT = {
+			has_variable = batavia_capital
+		}
 	}
 
 	option = {
@@ -32,6 +35,7 @@ dvg_batavia.1 = {
 		custom_tooltip = {
 		text = dvg_batavia_formed_tt
 			trigger_event = { id = dvg_batavia.2 days = 30 }
+			set_variable = batavia_capital
 			if = {
 				limit = {
 					has_law = law_type:law_state_religion


### PR DESCRIPTION
Previous checks for Batavia event didn't look for if the events had fired before, and so kept firing ad infinitum. This fix adds a check for a variable to the trigger, and adds a set variable command within the option for the first event, so the Primer can only fire once, and so only trigger the capital event once.