### PR TITLE
Fixed Freedom of Movement 3 exploitable bug

### DIFF
--- a/common/production_methods/06_urban_center.txt
+++ b/common/production_methods/06_urban_center.txt
@@ -324,7 +324,7 @@ pm_principle_freedom_of_movement_3 = {
 		principle_freedom_of_movement_3 
 	}
 	
-	country_modifiers = {
+	state_modifiers = {
 		unscaled = {
 			state_migration_pull_mult = 0.2
 		}


### PR DESCRIPTION
The mod was still using 1.7 base code, not the hotfixed 1.7.1 that stopped the massively exploitable +hundreds of percent national migration attraction