### PR TITLE
Rank comparison fixes

### DIFF
--- a/common/decisions/dvg_arcadia.txt
+++ b/common/decisions/dvg_arcadia.txt
@@ -434,7 +434,7 @@ dvg_buy_athesia = {
 
 		gold_reserves > 100000
 		c:VEN = {
-			global_country_ranking < rank_value:major_power 
+			country_rank < rank_value:major_power 
 			relations:root >= relations_threshold:amicable
 			OR = {
 				has_attitude = {

--- a/common/decisions/dvg_vinland.txt
+++ b/common/decisions/dvg_vinland.txt
@@ -205,7 +205,7 @@ dvg_masgirland_annexation = {
 		
 		c:VIN = {
 			is_diplomatic_play_committed_participant = no
-			global_country_ranking > rank_value:insignificant_power
+			country_rank > rank_value:insignificant_power
 		}
 		NOT = {
 			has_truce_with = c:VIN

--- a/common/journal_entries/dvg_belgium.txt
+++ b/common/journal_entries/dvg_belgium.txt
@@ -1175,7 +1175,7 @@ je_manifest_destiny_blc = {
 	fail = {
 		OR = {
 			has_law = law_type:law_no_colonial_affairs
-			global_country_ranking < rank_value:minor_power
+			country_rank < rank_value:minor_power
 			custom_tooltip = {
 				text = blc_fail_tt
 				OR = {

--- a/common/journal_entries/dvg_vinland.txt
+++ b/common/journal_entries/dvg_vinland.txt
@@ -419,7 +419,7 @@ je_arcadia_afn = {
 
 	possible = {
 		has_technology_researched = pan-nationalism
-		global_country_ranking > rank_value:insignificant_power
+		country_rank > rank_value:insignificant_power
 	}
 
 	immediate = {


### PR DESCRIPTION
global_country_ranking is your country ranking, not your country rank. I replaced the cases I could find where it was explicitly compared to a rank_value, as those are not comparable. 

For instance: the Buy Athesia decision looks like it intended to require Venice to be below a major power, but global_country_ranking made it so that it instead required it to be in the top 5 ranked countries.