### PR TITLE
Fix Jesuit Interference JE

### DIFF
--- a/common/scripted_buttons/dvg_arcadia_buttons.txt
+++ b/common/scripted_buttons/dvg_arcadia_buttons.txt
@@ -577,7 +577,6 @@ dvg_ban_missionaries_button_skr = {
 		if = {
 			limit = { 
 				has_journal_entry = je_skraeling_missions
-				has_variable = dvg_xijiao_var 
 			}
 			change_variable = {
 				name = dvg_skr_var


### PR DESCRIPTION
The Jesuit Interference JE can't be removed due to the game checking for a flag that shouldn't be there. Similar buttons in Chinese JEs check for it too, so I assume it just wasn't removed when reusing the code. 